### PR TITLE
Expand any multi-line commands

### DIFF
--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -311,6 +311,14 @@ def check_args(module, warnings):
                                  'single character')
 
 
+def expand_lines(lines):
+    newlines = list()
+    for thisline in lines:
+        for anotherline in thisline.split('\n'):
+            newlines.append(anotherline)
+    return newlines
+
+
 def get_candidate_config(module):
     candidate = ''
     if module.params['src']:
@@ -418,6 +426,9 @@ def main():
         match = module.params['match']
         replace = module.params['replace']
         path = module.params['parents']
+
+        if module.params['lines']:
+            module.params['lines'] = expand_lines(module.params['lines'])
 
         candidate = get_candidate_config(module)
         running = get_running_config(module, contents, flags=flags)


### PR DESCRIPTION
Loop through all the lines in module.params['lines'] and expand any multi-line commands into their own lines so they can be checked via difference().

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When ios_config has multiple commands on a single line it cannot correctly difference against the running config so the module detects a change and runs when nothing has actually changed.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->
Fixes #43842

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
